### PR TITLE
Fix Dependabot: Update httparty to 0.24.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@
 source 'https://rubygems.org'
 
 gem 'cli-ui'
-gem 'httparty'
-gem 'rubocop'
+gem 'httparty', '~> 0.22'
+gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,37 +1,54 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.0)
-    cli-ui (1.3.0)
-    httparty (0.17.3)
-      mime-types (~> 3.0)
+    ast (2.4.3)
+    bigdecimal (4.0.1)
+    cli-ui (2.7.0)
+    csv (3.3.5)
+    httparty (0.24.2)
+      csv
+      mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    jaro_winkler (1.5.4)
-    mime-types (3.3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.1009)
-    multi_xml (0.6.0)
-    parallel (1.19.1)
-    parser (2.7.0.2)
-      ast (~> 2.4.0)
-    rainbow (3.0.0)
-    rubocop (0.79.0)
-      jaro_winkler (~> 1.5.1)
+    json (2.18.1)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    mini_mime (1.1.5)
+    multi_xml (0.8.1)
+      bigdecimal (>= 3.1, < 5)
+    parallel (1.27.0)
+    parser (3.3.10.1)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    regexp_parser (2.11.3)
+    rubocop (1.84.1)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
       parallel (~> 1.10)
-      parser (>= 2.7.0.1)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
-    ruby-progressbar (1.10.1)
-    unicode-display_width (1.6.1)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   cli-ui
-  httparty
+  httparty (~> 0.22)
   rubocop
 
 BUNDLED WITH
-   1.17.3
+   2.4.19


### PR DESCRIPTION
## Summary
- Updates `httparty` from 0.17.3 to **0.24.2** to resolve both open Dependabot security alerts
- **Alert #1 (medium)**: multipart/form-data request tampering vulnerability (fixed in >= 0.21.0)
- **Alert #2 (high)**: SSRF vulnerability leading to API key leakage (fixed in >= 0.24.0)
- Updates `rubocop` (0.79.0 → 1.84.1) and `cli-ui` (1.3.0 → 2.7.0) for compatibility

## Test plan
- [x] Verify dependencies install correctly (`bundle install`)
- [x] Verify `lib/dns_update.rb` loads with updated httparty
- [x] Verify `cli/ui` loads with updated cli-ui